### PR TITLE
Remove unneeded SCP for S3 encryption

### DIFF
--- a/policy-groups/infrastructure-best-practices/main.tf
+++ b/policy-groups/infrastructure-best-practices/main.tf
@@ -45,29 +45,6 @@ data "aws_iam_policy_document" "combined_policy_block" {
   }
 
   dynamic "statement" {
-    for_each = var.require_s3_object_encryption ? [1] : []
-
-    content {
-      sid       = "RequireObjectEncryption"
-      effect    = "Deny"
-      actions   = ["s3:PutObject"]
-      resources = ["arn:aws:s3:::*/*"]
-
-      condition {
-        test     = "ForAllValues:StringNotEquals"
-        variable = "s3:x-amz-server-side-encryption"
-        values   = ["AES256", "aws:kms"]
-      }
-
-      condition {
-        test     = "Null"
-        variable = "s3:x-amz-server-side-encryption"
-        values   = ["true"]
-      }
-    }
-  }
-
-  dynamic "statement" {
     for_each = var.require_s3_bucket_https ? [1] : []
 
     content {


### PR DESCRIPTION
S3 encryption is [enabled by
default](https://aws.amazon.com/blogs/aws/amazon-s3-encrypts-new-objects-by-default/).
