### PR TITLE
Update RDS encryption SCP

### DIFF
--- a/policy-groups/infrastructure-best-practices/main.tf
+++ b/policy-groups/infrastructure-best-practices/main.tf
@@ -76,44 +76,18 @@ data "aws_iam_policy_document" "combined_policy_block" {
     for_each = var.require_rds_encryption ? [1] : []
 
     content {
-      sid       = "DenyNotAuroraDBInstance"
-      effect    = "Deny"
-      actions   = ["rds:CreateDBInstance"]
-      resources = ["*"]
-
-      condition {
-        test     = "ForAnyValue:StringEquals"
-        variable = "rds:DatabaseEngine"
-        values = [
-          "mariadb",
-          "mysql",
-          "oracle-ee",
-          "oracle-se",
-          "oracle-se1",
-          "oracle-se2",
-          "postgres",
-          "sqlserver-ee",
-          "sqlserver-ex",
-          "sqlserver-se",
-          "sqlserver-web",
-        ]
-      }
-
-      condition {
-        test     = "Bool"
-        variable = "rds:StorageEncrypted"
-        values   = [false]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.require_rds_encryption ? [1] : []
-
-    content {
-      sid       = "DenyAuroraDatabaseCluster"
-      effect    = "Deny"
-      actions   = ["rds:CreateDBCluster"]
+      sid    = "DenyUnencryptedRDS"
+      effect = "Deny"
+      actions = [
+        "rds:CreateDBInstance",
+        "rds:CreateDBCluster",
+        "rds:RestoreDBInstanceFromDBSnapshot",
+        "rds:RestoreDBInstanceFromS3",
+        "rds:RestoreDBInstanceToPointInTime",
+        "rds:RestoreDBClusterFromSnapshot",
+        "rds:RestoreDBClusterFromS3",
+        "rds:RestoreDBClusterToPointInTime",
+      ]
       resources = ["*"]
 
       condition {

--- a/policy-groups/infrastructure-best-practices/main.tf
+++ b/policy-groups/infrastructure-best-practices/main.tf
@@ -90,6 +90,7 @@ data "aws_iam_policy_document" "combined_policy_block" {
       actions = [
         "rds:CreateDBInstance",
         "rds:CreateDBCluster",
+        "rds:CreateGlobalCluster",
         "rds:RestoreDBInstanceFromS3",
         "rds:RestoreDBClusterFromS3",
       ]

--- a/policy-groups/infrastructure-best-practices/main.tf
+++ b/policy-groups/infrastructure-best-practices/main.tf
@@ -78,15 +78,20 @@ data "aws_iam_policy_document" "combined_policy_block" {
     content {
       sid    = "DenyUnencryptedRDS"
       effect = "Deny"
+      # The following restore APIs are intentionally omitted:
+      #   - rds:RestoreDBInstanceFromDBSnapshot
+      #   - rds:RestoreDBInstanceToPointInTime
+      #   - rds:RestoreDBClusterFromSnapshot
+      #   - rds:RestoreDBClusterToPointInTime
+      # These APIs do not expose StorageEncrypted as a request parameter, so
+      # rds:StorageEncrypted is not available for this condition. Restored DB
+      # encryption must be enforced by keeping source snapshots, backups, and
+      # DB resources encrypted.
       actions = [
         "rds:CreateDBInstance",
         "rds:CreateDBCluster",
-        "rds:RestoreDBInstanceFromDBSnapshot",
         "rds:RestoreDBInstanceFromS3",
-        "rds:RestoreDBInstanceToPointInTime",
-        "rds:RestoreDBClusterFromSnapshot",
         "rds:RestoreDBClusterFromS3",
-        "rds:RestoreDBClusterToPointInTime",
       ]
       resources = ["*"]
 


### PR DESCRIPTION
The SCP is intended to block the creation of unencrypted RDS resources
(regardless of engine), so this update reflects that.
